### PR TITLE
Apply 2to3 fixes on plugins

### DIFF
--- a/plugins/src/allow_execstack.py
+++ b/plugins/src/allow_execstack.py
@@ -23,19 +23,19 @@ _=translation.gettext
 from setroubleshoot.util import *
 from setroubleshoot.Plugin import Plugin
 
-import commands
+import subprocess
 import sys
 
 def is_execstack(path):
     if path[0] != "/":
         return False
 
-    x = commands.getoutput("execstack -q %s" %   path).split()
+    x = subprocess.getoutput("execstack -q %s" %   path).split()
     return ( x[0]  == "X" )
 
 def find_execstack(exe, pid):
     execstacklist = []
-    for path in commands.getoutput("ldd %s" %   exe).split():
+    for path in subprocess.getoutput("ldd %s" %   exe).split():
         if is_execstack(path) and path not in execstacklist:
                 execstacklist.append(path)
     try:

--- a/plugins/src/catchall_boolean.py
+++ b/plugins/src/catchall_boolean.py
@@ -21,6 +21,7 @@
 
 import gettext
 import os
+import six
 translation=gettext.translation('setroubleshoot-plugins', fallback=True)
 _=translation.gettext
 
@@ -57,8 +58,8 @@ class plugin(Plugin):
 
     def get_if_text(self, avc, args):
         txt=seobject.boolean_desc(args[0])
-        if not isinstance(txt, unicode):
-            txt=unicode(txt, encoding="utf8")
+        if not isinstance(txt, six.text_type):
+            txt=six.text_type(txt, encoding="utf8")
         return _("you want to %s") % (txt[0].lower() + txt[1:])
         
     def get_do_text(self, avc, args):

--- a/plugins/src/disable_ipv6.py
+++ b/plugins/src/disable_ipv6.py
@@ -24,7 +24,7 @@ _=translation.gettext
 from setroubleshoot.util import *
 from setroubleshoot.Plugin import Plugin
 import re
-import os, commands
+import os
 
 class plugin(Plugin):
     summary =_('''

--- a/plugins/src/findexecstack
+++ b/plugins/src/findexecstack
@@ -1,17 +1,17 @@
 #! /usr/bin/python
-import commands
+import subprocess
 import sys
 
 def is_execstack(path):
     if path[0] != "/":
         return False
 
-    x = commands.getoutput("execstack -q %s" %   path).split()
+    x = subprocess.getoutput("execstack -q %s" %   path).split()
     return ( x[0]  == "X" )
 
 def find_execstack(exe, pid):
     execstacklist = []
-    for path in commands.getoutput("ldd %s" %   sys.argv[1]).split():
+    for path in subprocess.getoutput("ldd %s" %   sys.argv[1]).split():
         if is_execstack(path) and path not in execstacklist:
                 execstacklist.append(path)
     try:
@@ -34,9 +34,9 @@ except:
 try:
 	path=sys.argv[1]
 	for i in find_execstack(path, pid):
-	    print "execstack -c   %s" %  i
+	    print("execstack -c   %s" %  i)
 except:
-	print "Usage:  %s  executable [ pid ]" % sys.argv[0]
+	print("Usage:  %s  executable [ pid ]" % sys.argv[0])
 
 
 

--- a/plugins/src/restorecon.py
+++ b/plugins/src/restorecon.py
@@ -116,7 +116,7 @@ class plugin(Plugin):
                 mcon_type=mcon.split(":")[2]
                 if mcon_type != avc.tcontext.type:
                     return self.report((0, mcon_type))
-            except OSError, e:
+            except OSError as e:
                 pass
 
         return None


### PR DESCRIPTION
Attempt to fix Python 3 incompatibilities in plugins, for example:

Jul 29 12:59:30 localhost.localdomain setroubleshoot[19867]: failed to load disable_ipv6 plugin
Jul 29 12:59:30 localhost.localdomain setroubleshoot[19867]: failed to load restorecon plugin
Jul 29 12:59:30 localhost.localdomain setroubleshoot[19867]: failed to load allow_execstack plugin
